### PR TITLE
feat: add reusable workflow to build openedx images 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,11 @@ jobs:
         with:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      - name: Add GitHub to known hosts
+        shell: bash
+        run: |
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
       - name: Execute extra commands
         shell: bash
         working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}


### PR DESCRIPTION
## Description
Add [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) to build Open edX images based on the [Picasso V2 pipeline](https://github.com/eduNEXT/dedalo-scripts/tree/main/jenkins) definition. The main goal of this implementation is to prove the feasibility of adopting Github Actions to replace Jenkins for our current build process. For more details on the team's stand on the potential migration, please visit [this post](https://3.basecamp.com/3966315/buckets/12732851/messages/7542884335).

### Implementation details

For this implementation, we first translated each step in the current Picaso V2 pipeline to its counterpart in GH actions. Then, we refactored them into smaller steps when possible for easier management. Here's an overview of the translation of each stage into steps:

**Jenkins pipeline stages**
1. Login in Dockerhub
2. Clone strains repository
3. Get Global Variables
3.1 Set strain name for TVM use
3.2 Set tutor version for TVM use
4. Configure TVM project
4.1 Install TVM
4.2 Initialize TVM project
4.3 Copies strain into project folder
4.4  Generates tutor environment 
5. Execute extra commands
5.1 Update plugin index
5.2 List plugins
5.3 Enable distro
5.4 Run syntax validation
5.5 Run distro run-extra-commands
5.6 Generates tutor environment
6. Build Service
7. Push service

**GitHub steps**
1. Login in Dockerhub
2. Checkout strains repository
3. Set TVM project name and version in Github Environment
4. Install TVM
5. Configure TVM project
5.1 Install TVM
5.2 Initialize TVM project
5.3 Copies strain into project folder
6. Enable distro plugin
7. Execute extra commands (run-extra-commands)
8. Prepare docker if building MFE (optional)
9. Build service image with no cache
10. Push service image to DockerHub

Other design details to take into account:
- The caller workflow determines the default values.
- It will only be called from private repositories by the repository configuration unless we make this repository public (TBD)
- Each team needing to modify workflow secrets must maintain its caller workflow with those credentials.
- No syntax validation has been implemented for now.
- To avoid [connection errors](https://github.com/eduNEXT/ednx-strains/actions/runs/10190442265/job/28190308225#step:9:2581) while building MFE images, we must use a custom build kit configuration file to restrict the number of parallel stages. See these posts for more info on the errors: https://discuss.openedx.org/t/npm-err-code-err-socket-timeout-when-building-mfe-image/10414, https://github.com/overhangio/tutor-mfe/issues/55#issuecomment-2006605074. The root cause is still unknown. 

## How to test

1. We need to create a caller workflow that uses this reusable (called) workflow. For reference, see [the implementation details](https://github.com/eduNEXT/ednx-strains/blob/master/.github/workflows/build.yml#L33). The `build.yml` workflow actively uses the `picasso/build.yml` workflow and sets the necessary configurations to run correctly.
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, or use the default. I suggest using the `MJG/redwood-test-image` strain branch to avoid overriding the current image on dockerhub.
3. Press run workflow.

![image](https://github.com/user-attachments/assets/86216aed-dac8-4424-a0aa-f3f245988505)

See here a successful build: https://github.com/eduNEXT/ednx-strains/actions/runs/10208033113/job/28243841700
