### PR TITLE
feat: use self-hosted runners to improve build performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ on:
         description: 'The service name to build'
         required: true
         type: string
+      AWS_EC2_INSTANCE_TYPE:
+        description: 'The EC2 instance type to start'
+        required: true
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         description: 'DockerHub username for login'
@@ -29,10 +33,56 @@ on:
       SSH_PRIVATE_KEY:
         description: 'Service user SSH key for repository checkout'
         required: true
+      GH_PERSONAL_ACCESS_TOKEN:
+        description: 'GitHub personal access token'
+        required: true
+      AWS_ACCESS_KEY_ID:
+        description: 'AWS access key ID'
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: 'AWS secret access key'
+        required: true
+      AWS_REGION:
+        description: 'AWS region'
+        required: true
+      AWS_EC2_IMAGE_ID:
+        description: 'AWS EC2 image ID'
+        required: true
+      AWS_SUBNET_ID:
+        description: 'AWS subnet ID'
+        required: true
+      AWS_SECURITY_GROUP_ID:
+        description: 'AWS security group ID'
+        required: true
 
 jobs:
-  build:
+  start-runner:
+    name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ secrets.AWS_EC2_IMAGE_ID }}
+          ec2-instance-type: ${{ inputs.AWS_EC2_INSTANCE_TYPE }}
+          subnet-id: ${{ secrets.AWS_SUBNET_ID }}
+          security-group-id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
+  build:
+    name: Build service image
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
 
     steps:
       - name: Login to DockerHub
@@ -169,3 +219,25 @@ jobs:
         run: |
           . .tvm/bin/activate
           tutor images push $SERVICE
+
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,8 +215,8 @@ jobs:
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:
-      - start-runner # required to get output from the start-runner job
-      - build # required to wait when the main job is done
+      - start-runner
+      - build
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -221,7 +221,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,14 +193,6 @@ jobs:
           . .tvm/bin/activate
           tutor distro run-extra-commands
 
-      - name: Prepare docker if building MFE
-        if: ${{ inputs.SERVICE == 'mfe' }}
-        shell: bash
-        run: |
-          echo "[worker.oci]" > buildkit.toml
-          echo "max-parallelism = 2" >> buildkit.toml
-          docker buildx create --use --node=max2cpu --driver=docker-container --config=./buildkit.toml
-
       - name: Build service image with no cache
         shell: bash
         working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}


### PR DESCRIPTION
## Description
This PR implements two GH jobs: provisioning and stopping self-hosted runners used to build docker images for the Open edX ecosystem. Each runner is provisioned as an AWS EC2 instance with enough resources to improve building performance without impacting the billing. In this current setup, a new instance is provisioned every time a new build workflow is executed. 

For provisioning EC2 AWS instances, I chose to use the https://github.com/marketplace/actions/on-demand-self-hosted-aws-ec2-runner-for-github-actions action for the number of stars, the documentation available and because it's listed on the awesome-runners comparison table.  

You can review here the configuration needed to use this workflow with self-hosted runners: https://github.com/eduNEXT/ednx-strains/blob/MJG/self-hosted-runners/.github/workflows/build.yml 

### Jenkins vs GHA

#### Setup

The main difference in setup relies on how many instances are provisioned per building job. While Jenkins provisions a single instance for a new build, if an instance with enough idle processes already exists (max number: 3) then an idle process is used for the next build to leverage resources. GHA provisions a new instance for each build job instead. So, while Jenkins uses 2 instances for 6 build jobs, GHA uses 6, increasing costs when building multiple images concurrently. I tried using m5.xlarge instead of m6i.2xlarge, which is the Jenkins agents default instance type, but the performance was impacted considerably: https://github.com/eduNEXT/ednx-strains/actions/runs/10479622786 since it's similar to the github hosted runner resources.

Also, while our Jenkins setup might support spot instances with additional plugins ([ref](https://aws.amazon.com/blogs/compute/cost-optimize-your-jenkins-ci-cd-pipelines-using-ec2-spot-instances/)), the action chosen for this implementation does not support it for the time being: https://github.com/machulav/ec2-github-runner/issues/5

In this current setup, we're using the same instance type as Jenkins agents unless indicated otherwise.

#### Time comparison

**Provision time** 

Provisioning time varies between the two. The process of provisioning an instance with Jenkins takes about ~2min, time I measured by hand because I did not find any data for this in Jenkins, while in GHA, it takes about ~4min [actions/runs/10458288173](https://github.com/eduNEXT/ednx-strains/actions/runs/10458288173) (see usage > Start self-hosted EC2 runner). See other builds for comparison [actions/runs/10479549584](https://github.com/eduNEXT/ednx-strains/actions/runs/10479549584),  [actions/runs/10479182910](https://github.com/eduNEXT/ednx-strains/actions/runs/10479182910), [actions/runs/10475792028](https://github.com/eduNEXT/ednx-strains/actions/runs/10475792028)

**Build time** 

For building openedx images, the [build step time](https://github.com/eduNEXT/ednx-strains/actions/runs/10458288173) in GHA takes about ~25 min, a similar time to [this build stage](https://picasso.dedalo.edunext.co/job/PICASSO_V2/526/) in Jenkins with the same parameters. Those tests were executed with this simple configuration file: [redwood/base/config.yml](https://github.com/eduNEXT/ednx-strains/blob/b79dfafae6c225a9a9456f67ed019a2d1de16937/redwood/base/config.yml). For the latest redwood image [redwood/base/config.yml](https://github.com/eduNEXT/ednx-strains/blob/MJG/self-hosted-runners/redwood/base/config.yml), both take about the same time as well. You can go ahead and review other builds on Jenkins and GHA for comparison.

For building MFE images, the [build step time](https://github.com/eduNEXT/ednx-strains/actions/runs/10479182910) in GHA takes about ~19 min, a similar time to the ~20min [this build stage](https://picasso.dedalo.edunext.co/job/PICASSO_V2/531/) in Jenkins with the same parameters. Those tests were executed with this simple configuration file:

**Total execution time:** 
The total execution recorded in GHA for building openedx images is 30m 59s [actions/runs/10458288173/usage](https://github.com/eduNEXT/ednx-strains/actions/runs/10458288173/usage), while on Jenkins is ~31 min from “scheduled” to “completion” https://picasso.dedalo.edunext.co/job/PICASSO_V2/526/

The total execution recorded in GHA for building MFE images is 23m 36s [actions/runs/10479182910/usage](https://github.com/eduNEXT/ednx-strains/actions/runs/10479182910/usage), while on Jenkins is 25min https://picasso.dedalo.edunext.co/job/PICASSO_V2/531/.

We must consider that not all jenkins steps have their corresponding translation in GHA, for example to do syntax checks, then GHA could take a little longer.

In this spreadsheet you can better review the time comparison across a considerable number of builds: https://docs.google.com/spreadsheets/d/1PtiRz4OBj3XxkY3xUUAi827vFtytWrox6ztK6XaqGkY/edit?usp=sharing

## How to test

1. We need to create a caller workflow that uses this reusable (called) workflow. For reference, see [the implementation details](https://github.com/eduNEXT/ednx-strains/blob/master/.github/workflows/build.yml#L33). The `build.yml` workflow actively uses the `picasso/build.yml` workflow and sets the necessary configurations to run correctly.
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, or use the default. For self-hosted runners, use the workflow from the branch `MJG/self-hosted-runners`, also use the `MJG/redwood-test-image` strain branch to avoid overriding the current image on dockerhub.
3. Press run workflow.
4. Go to Actions > Runners > Self hosted, you'll see the new self-hosted runner there.

You won't be able to test until we generate a fine-grained PAT for cloning ednx-strain.

See here a successful build: https://github.com/eduNEXT/ednx-strains/actions/runs/10479622786
