### PR TITLE
refactor: drop tvm unnecessary use for current setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,73 +48,49 @@ jobs:
           ref: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Set TVM project name and version
+      - name: Setup virtualenv
         shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}
         run: |
-          if [ ! -e "./config.yml" ]; then
-            echo "ERROR: file config.yml doesn't exist"
-            exit 1 # terminate and indicate error
-          fi
+          python -m venv venv
+          . venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+
+      - name: Get tutor version from config.yml
+        shell: python
+        run: |
+          import os
+          import yaml
+
+          config_path = os.path.join('${{ inputs.STRAIN_PATH }}', 'config.yml')
+
+          if not os.path.exists(config_path):
+            print("ERROR: file config.yml doesn't exist")
+            exit(1)
 
           # Initialize variables
-          strain_name=""
-          strain_tutor_version=""
+          strain_tutor_version = ""
 
-          # Read config.yml line by line
-          while IFS= read -r line || [[ -n $line ]]; do
-            if [[ "$line" == *":"* ]]; then
-              name=$(echo "$line" | cut -d ":" -f1)
-              value=$(echo "$line" | cut -d ":" -f2- | awk '{$1=$1};1' | tr -d '\r')
+          with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
 
-              case $name in
-                *"TUTOR_APP_NAME"*)
-                  strain_name=$value
-                  ;;
-                *"TUTOR_VERSION"*)
-                  strain_tutor_version=$value
-                  ;;
-              esac
-            fi
-          done < "config.yml"
+          if 'TUTOR_VERSION' in config:
+            strain_tutor_version = config['TUTOR_VERSION'][1:]
 
-          # Check if variables are set
-          if [ -z "$strain_name" ]; then
-            echo "ERROR: TUTOR_APP_NAME not found in the given config.yml" >&2
-            exit 1
-          fi
+            if not strain_tutor_version:
+              print("ERROR: TUTOR_VERSION not found in the given config.yml", file=sys.stderr)
+              exit(1)
 
-          if [ -z "$strain_tutor_version" ]; then
-            echo "ERROR: TUTOR_VERSION not found in the given config.yml" >&2
-            exit 1
-          fi
+            print(f"TUTOR_VERSION={strain_tutor_version}", file=open(os.environ['GITHUB_ENV'], 'a'))
 
-          echo "TUTOR_APP_NAME=${strain_name}" >> $GITHUB_ENV
-          echo "TUTOR_VERSION=${strain_tutor_version}" >> $GITHUB_ENV
-
-      - name: Install TVM
+      - name: Install Tutor version from config.yml
         shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}
         run: |
-          pip install git+https://github.com/eduNEXT/tvm.git
-
-      - name: Configure TVM project
-        shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}
-        run: |
-          tvm install $TUTOR_VERSION
-          tvm project init $TUTOR_APP_NAME $TUTOR_VERSION
-
-          # This command copies all the files and folders
-          # from the repository STRAIN_PATH to the recently above created TVM PROJECT folder
-          cp -r $(ls --ignore=$TUTOR_APP_NAME) $TUTOR_APP_NAME/
+          pip install tutor==$TUTOR_VERSION
 
       - name: Enable picasso plugin
         shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
+        working-directory: ${{ inputs.STRAIN_PATH }}
         run: |
-          . .tvm/bin/activate
-
           pip install git+https://github.com/eduNEXT/tutor-contrib-picasso
           tutor plugins enable picasso
 
@@ -130,9 +106,8 @@ jobs:
 
       - name: Execute extra commands
         shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
+        working-directory: ${{ inputs.STRAIN_PATH }}
         run: |
-          . .tvm/bin/activate
           tutor picasso run-extra-commands
 
       - name: Prepare docker if building MFE
@@ -145,19 +120,17 @@ jobs:
 
       - name: Build service image with no cache
         shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
+        working-directory: ${{ inputs.STRAIN_PATH }}
         env:
           SERVICE: ${{ inputs.SERVICE }}
         run: |
-          . .tvm/bin/activate
           tutor config save
-          tutor images build $SERVICE --no-cache
+          tutor images build $SERVICE
 
       - name: Push service image to DockerHub
         shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
+        working-directory: ${{ inputs.STRAIN_PATH }}
         env:
           SERVICE: ${{ inputs.SERVICE }}
         run: |
-          . .tvm/bin/activate
           tutor images push $SERVICE


### PR DESCRIPTION
Drop TVM use since it's unnecessary considering the isolation level of each instance. This should be revisited later in case there's gonna be instance reuse, but for now, it's better to drop for simplicity. Also, only get TUTOR_VERSION by running a simple python script.