### PR TITLE
refactor: drop tvm unnecessary use in current setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup Virtual Environment
         run: |
-          python -m venv .tvm
+          python -m venv venv
           . venv/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
 
@@ -91,13 +91,13 @@ jobs:
           echo "PICASSO_TUTOR_VERSION=${strain_tutor_version:1}" >> $GITHUB_ENV
 
       - name: Install Tutor version from config.yml
+        env:
+          TUTOR_VERSION: ${{ env.PICASSO_TUTOR_VERSION }}
         run: |
           pip install tutor==$TUTOR_VERSION
 
       - name: Enable picasso plugin
         run: |
-          . .tvm/bin/activate
-
           pip install git+https://github.com/eduNEXT/tutor-contrib-picasso@mfmz/fix-themes
           tutor plugins enable picasso
 


### PR DESCRIPTION
### Description
Drop TVM use since it's unnecessary considering the isolation level of each instance. This should be revisited later in case there's gonna be instance reuse, but for now, it's better to drop for simplicity. Also, simplify steps after removal.