### PR TITLE
feat: add support for pushing AWS registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,20 +79,20 @@ jobs:
 
           required_keys = ["TUTOR_VERSION", "TUTOR_APP_NAME"]
           optional_keys = ["DOCKER_REGISTRY"]
-          env_vars = ""
+          env_vars = []
 
           for key in required_keys:
             if key not in tutor_config:
               print(f"ERROR: key {key} not found in config.yml")
               sys.exit(1)
-            env_vars += (f"{key}={tutor_config[key]}\n")
+            env_vars.append(f"{key}={tutor_config[key]}")
 
           for key in optional_keys:
             if key in tutor_config:
-              env_vars += (f"{key}={tutor_config[key]}\n")
+              env_vars.append(f"{key}={tutor_config[key]}")
 
           with open(os.environ["GITHUB_ENV"], "a") as file:
-            file.write(env_vars.strip())
+            file.write("\n".join(env_vars))
 
       - name: Install TVM
         shell: bash


### PR DESCRIPTION
### Description

This PR implements an additional registry to push Docker images depending on the value of the `DOCKER_REGISTRY` configuration. By default, `DOCKER_REGISTRY` is set to `docker.io/`, so the image will be stored in that registry when that's the case. If set to `AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com` or simply `aws`, it will be pushed to the AWS registry. 

More info on the solution: [AP-1348](https://edunext.atlassian.net/browse/AP-1348?focusedCommentId=38918 )

[AP-1348]: https://edunext.atlassian.net/browse/AP-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### How to test

1. Go to edxn-strains repository where the caller workflow for Picasso is hosted: https://github.com/eduNEXT/ednx-strains/actions
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, please use the workflow version from `MJG/support-diff-registries`. For the strain to build, I suggest using the `MJG/support-diff-registries` strain branch to use the configuration for AWS.
3. Press run workflow.
4. To check whether the image was pushed to our registry login to the AWS Console. After selecting the team's role, go to Services > Elastic Container Registry and check the repository I created for our images.

Here's a successful build: https://github.com/eduNEXT/ednx-strains/actions/runs/10856268800/job/30130588952