### PR TITLE
refactor: limit resource consumption for gh-runners by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           echo "[worker.oci]
           max-parallelism = 3" > buildkit.toml
-          docker buildx create --use --node=max2parallelsteps --driver=docker-container --config=./buildkit.toml
+          docker buildx create --use --node=limitparallelsteps --driver=docker-container --config=./buildkit.toml
 
       - name: Build service image with no cache
         shell: bash


### PR DESCRIPTION
## Description

This PR enables limiting parallelism with buildkit to a max of 2 parallel build steps that can run at the same time to decrease resource consumption for those setups with low-powered machines:  [build/buildkit/configure/#max-parallelism](https://docs.docker.com/build/buildkit/configure/#max-parallelism). These changes solve the issues we've been having with the standard gh-hosted runners halting builds (see [Build 76](https://github.com/eduNEXT/ednx-strains/actions/runs/10721484222))  with configurations that take up more resources than usual, like those setups with custom themes. 

## How to test

1. Go to edxn-strains repository where the caller workflow for Picasso is hosted: https://github.com/eduNEXT/ednx-strains/actions
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, please use the workflow version from `MJG/limit-resources`. For the strain to build, I suggest using the `MJG/limited-resources` strain branch to avoid overriding the current image on dockerhub. I've tested using the `redwood/base` and `redwood/colors` strains.
3. Press run workflow.

Here are some successful executions:
https://github.com/eduNEXT/ednx-strains/actions/runs/10828357346
https://github.com/eduNEXT/ednx-strains/actions/runs/10827983449
https://github.com/eduNEXT/ednx-strains/actions/runs/10827709143