### PR TITLE
refactor: use python scripts instead of bash for handling logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,12 +83,6 @@ jobs:
             with open(github_env, "a") as env_file:
               env_file.write(f"{key}={tutor_config[key]}\n")
 
-      - name: Install TVM
-        shell: bash
-        working-directory: ${{ inputs.STRAIN_PATH }}
-        run: |
-          pip install git+https://github.com/eduNEXT/tvm.git
-
       - name: Configure TVM project
         shell: bash
         working-directory: ${{ inputs.STRAIN_PATH }}


### PR DESCRIPTION
### Description

This PR is the starting point for a proposal to handle scripts in a more maintainable way. Here are the details:
- Use python scripts instead of bash
- Figuring out a way of making those scripts more maintainable long-term
- Adding linting, tests (TBD)
- Making them reusable if needed

For now, Python scripts (and any other script) need to be hardcoded into the workflow until I figure out a good way of checking out the reusable workflow in the caller workflow. More context here: https://github.com/orgs/community/discussions/68735

### How to test

1. Go to edxn-strains repository where the caller workflow for Picasso is hosted: https://github.com/eduNEXT/ednx-strains/actions
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, please use the workflow version from `MJG/workflow-python-scripts`. For the strain to build, I suggest using the `MJG/workflow-python-scripts` strain branch to avoid overriding the current image on dockerhub. In this case, you don't need to wait for the workflow to finish to know it works, just check the TVM environment was created.
3. Press run workflow.

