### PR TITLE
feat: add support for pushing AWS registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,25 +27,28 @@ on:
     secrets:
       DOCKERHUB_USERNAME:
         description: 'DockerHub username for login'
-        required: true
+        required: false
       DOCKERHUB_PASSWORD:
         description: 'DockerHub password for login'
-        required: true
+        required: false
       SSH_PRIVATE_KEY:
         description: 'Service user SSH key for repository checkout'
         required: true
+      AWS_ACCESS_KEY_ID:
+        description: 'AWS access key ID'
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        description: 'AWS secret access key'
+        required: false
+      AWS_REGION:
+        description: 'AWS region'
+        required: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Checkout strains repository
         uses: actions/checkout@v4
         with:
@@ -74,14 +77,22 @@ jobs:
           with open(file_path, "r", encoding="utf-8") as file:
             tutor_config = yaml.safe_load(file)
 
-          for key in ["TUTOR_VERSION", "TUTOR_APP_NAME"]:
+          required_keys = ["TUTOR_VERSION", "TUTOR_APP_NAME"]
+          optional_keys = ["DOCKER_REGISTRY"]
+          env_vars = []
+
+          for key in required_keys:
             if key not in tutor_config:
               print(f"ERROR: key {key} not found in config.yml")
               sys.exit(1)
+            env_vars.append(f"{key}={tutor_config[key]}")
 
-            github_env = os.getenv("GITHUB_ENV")
-            with open(github_env, "a") as env_file:
-              env_file.write(f"{key}={tutor_config[key]}\n")
+          for key in optional_keys:
+            if key in tutor_config:
+              env_vars.append(f"{key}={tutor_config[key]}")
+
+          with open(os.environ["GITHUB_ENV"], "a") as file:
+            file.write("\n".join(env_vars))
 
       - name: Configure TVM project
         shell: bash
@@ -128,6 +139,26 @@ jobs:
           max-parallelism = 3" > buildkit.toml
           docker buildx create --use --node=limitparallelsteps --driver=docker-container --config=./buildkit.toml
 
+      - name: Configure AWS credentials
+        if: ${{ contains(env.DOCKER_REGISTRY, 'aws') }}
+        uses: aws-actions/configure-aws-credentials@v4
+        id: login-ecr
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to AWS ECR if Docker registry is AWS
+        if: ${{ contains(env.DOCKER_REGISTRY, 'aws') }}
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Login to DockerHub if Docker registry is DockerHub or not set
+        if: ${{ env.DOCKER_REGISTRY == null || contains(env.DOCKER_REGISTRY, 'docker.io') }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Build service image with no cache
         shell: bash
         working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
@@ -138,8 +169,7 @@ jobs:
           tutor config save
           tutor images build $SERVICE --no-cache
 
-      - name: Push service image to DockerHub
-        shell: bash
+      - name: Push service image to registry
         working-directory: ${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
         env:
           SERVICE: ${{ inputs.SERVICE }}


### PR DESCRIPTION
### Description

This PR implements an additional registry to push Docker images depending on the value of the `DOCKER_REGISTRY` configuration. By default, `DOCKER_REGISTRY` is set to `docker.io/`, so the image will be stored in that registry when that's the case. If set to `AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com` or simply `aws`, it will be pushed to the AWS registry. 

More info on the solution: [AP-1348](https://edunext.atlassian.net/browse/AP-1348?focusedCommentId=38918 )

[AP-1348]: https://edunext.atlassian.net/browse/AP-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### How to test

1. Go to edxn-strains repository where the caller workflow for Picasso is hosted: https://github.com/eduNEXT/ednx-strains/actions
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, please use the workflow version from `MJG/support-diff-registries`. For the strain to build, I suggest using the `MJG/support-diff-registries` strain branch to use the configuration for AWS.
3. Press run workflow.
4. To check whether the image was pushed to our registry login to the AWS Console. After selecting the team's role, go to Services > Elastic Container Registry and check the repository I created for our images.

Here's a successful build: https://github.com/eduNEXT/ednx-strains/actions/runs/10856268800/job/30130588952