### PR TITLE
docs: document the use of run-name to better identify workflow runs

### DIFF
--- a/docs/reuse_workflow.rst
+++ b/docs/reuse_workflow.rst
@@ -20,30 +20,30 @@ Here is an example of how to use the Picasso workflow using the `workflow_dispat
     on:
         workflow_dispatch:
             inputs:
-            STRAIN_REPOSITORY:
-                description: 'Repository to clone the configuration from'
-                default: 'eduNEXT/build-manifests'
-                type: string
-            STRAIN_REPOSITORY_BRANCH:
-                description: 'Branch to clone the configuration from'
-                default: 'master'
-                type: string
-            STRAIN_PATH:
-                description: 'Path to the configuration within the repository'
-                default: 'redwood/base'
-                type: string
-            SERVICE:
-                description: 'Service to build'
-                default: 'openedx'
-                type: choice
-                options:
-                - openedx
-                - mfe
-                - codejail
-                - aspects
-                - aspects-superset
-                - ecommerce
-                - discovery
+                STRAIN_REPOSITORY:
+                    description: 'Repository to clone the configuration from'
+                    default: 'eduNEXT/build-manifests'
+                    type: string
+                STRAIN_REPOSITORY_BRANCH:
+                    description: 'Branch to clone the configuration from'
+                    default: 'master'
+                    type: string
+                STRAIN_PATH:
+                    description: 'Path to the configuration within the repository'
+                    default: 'redwood/base'
+                    type: string
+                SERVICE:
+                    description: 'Service to build'
+                    default: 'openedx'
+                    type: choice
+                    options:
+                    - openedx
+                    - mfe
+                    - codejail
+                    - aspects
+                    - aspects-superset
+                    - ecommerce
+                    - discovery
 
     jobs:
         build:
@@ -70,10 +70,10 @@ Here's an example of how to use the Picasso workflow using the `push`_ event:
     on:
         push:
             branches:
-            - master
-            - main
+                - master
+                - main
             paths:
-            - 'redwood/base/**'
+                - 'redwood/base/**'
 
     jobs:
         build:

--- a/docs/trigger_build_with_cli.rst
+++ b/docs/trigger_build_with_cli.rst
@@ -9,30 +9,30 @@ Consider you're using the Picasso Workflow like in the following snippet to buil
     on:
     workflow_dispatch:
         inputs:
-        STRAIN_REPOSITORY:
-            description: 'Repository to clone the configuration from'
-            default: 'eduNEXT/build-manifests'
-            type: string
-        STRAIN_REPOSITORY_BRANCH:
-            description: 'Branch to clone the configuration from'
-            default: 'master'
-            type: string
-        STRAIN_PATH:
-            description: 'Path to the configuration within the repository'
-            default: 'redwood/base'
-            type: string
-        SERVICE:
-            description: 'Service to build'
-            default: 'openedx'
-            type: choice
-            options:
-            - openedx
-            - mfe
-            - codejail
-            - aspects
-            - aspects-superset
-            - ecommerce
-            - discovery
+            STRAIN_REPOSITORY:
+                description: 'Repository to clone the configuration from'
+                default: 'eduNEXT/build-manifests'
+                type: string
+            STRAIN_REPOSITORY_BRANCH:
+                description: 'Branch to clone the configuration from'
+                default: 'master'
+                type: string
+            STRAIN_PATH:
+                description: 'Path to the configuration within the repository'
+                default: 'redwood/base'
+                type: string
+            SERVICE:
+                description: 'Service to build'
+                default: 'openedx'
+                type: choice
+                options:
+                - openedx
+                - mfe
+                - codejail
+                - aspects
+                - aspects-superset
+                - ecommerce
+                - discovery
 
     jobs:
     build:


### PR DESCRIPTION
### Description

This PR adds documentation regarding the run-name of caller workflows so they're easier to identify when building. See an example here: https://github.com/eduNEXT/ednx-strains/actions