### PR TITLE
refactor: drop TVM for cleaner implementation in isolated environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install Tutor and its dependencies from the version specified in the config.yml
         run: |
-          pip install tutor[full]==$TUTOR_VERSION
+          pip install git+https://github.com/overhangio/tutor.git@$TUTOR_VERSION
           tutor config save
 
       - name: Enable and install picasso plugin in Tutor environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Get Tutor Configurations from config.yml and set them as an environment variable
         working-directory: ${{ github.workspace }}
         env:
-          REQUIRED_KEYS: TUTOR_VERSION TUTOR_APP_NAME
+          REQUIRED_KEYS: TUTOR_VERSION
           OPTIONAL_KEYS: DOCKER_REGISTRY
           CONFIG_FILE: strains/${{ inputs.STRAIN_PATH }}/config.yml
           SCRIPT_PATH: picasso/.github/workflows/scripts/get_tutor_config.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
     defaults:
       run:
         shell: bash
+        working-directory: strains/${{ inputs.STRAIN_PATH }}
+    env:
+      TUTOR_ROOT: strains/${{ inputs.STRAIN_PATH }}
+      TUTOR_PLUGINS_ROOT: strains/${{ inputs.STRAIN_PATH }}/plugins
 
     steps:
       - name: Checkout Picasso repository for utility scripts
@@ -70,9 +74,9 @@ jobs:
       - name: Install necessary dependencies
         run: |
           pip install pyyaml
-          pip install git+https://github.com/eduNEXT/tvm.git
 
       - name: Get Tutor Configurations from config.yml and set them as an environment variable
+        working-directory: ${{ github.workspace }}
         env:
           REQUIRED_KEYS: TUTOR_VERSION TUTOR_APP_NAME
           OPTIONAL_KEYS: DOCKER_REGISTRY
@@ -82,21 +86,13 @@ jobs:
           ENV_VARS=$(python $SCRIPT_PATH --config-file $CONFIG_FILE --required-keys $REQUIRED_KEYS --optional-keys $OPTIONAL_KEYS)
           echo "$ENV_VARS" >> $GITHUB_ENV
 
-      - name: Configure TVM project
-        working-directory: strains/${{ inputs.STRAIN_PATH }}
+      - name: Install Tutor and its dependencies from the version specified in the config.yml
         run: |
-          tvm install $TUTOR_VERSION
-          tvm project init $TUTOR_APP_NAME $TUTOR_VERSION
-
-          # This command copies all the files and folders
-          # from the repository STRAIN_PATH to the recently above created TVM PROJECT folder
-          cp -r $(ls --ignore=$TUTOR_APP_NAME) $TUTOR_APP_NAME/
+          pip install tutor[full]==$TUTOR_VERSION
+          tutor config save
 
       - name: Enable and install picasso plugin in Tutor environment
-        working-directory: strains/${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
         run: |
-          . .tvm/bin/activate
-
           pip install git+https://github.com/eduNEXT/tutor-contrib-picasso@v0.1.1
           tutor plugins enable picasso
 
@@ -110,9 +106,7 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
       - name: Execute extra commands
-        working-directory: strains/${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
         run: |
-          . .tvm/bin/activate
           tutor picasso run-extra-commands
 
       - name: Limit build parallelism to decrease resource usage
@@ -143,18 +137,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build service image with no cache
-        working-directory: strains/${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
         env:
           SERVICE: ${{ inputs.SERVICE }}
         run: |
-          . .tvm/bin/activate
           tutor config save
           tutor images build $SERVICE --no-cache
 
       - name: Push service image to registry
-        working-directory: strains/${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
         env:
           SERVICE: ${{ inputs.SERVICE }}
         run: |
-          . .tvm/bin/activate
           tutor images push $SERVICE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
         shell: bash
         working-directory: strains/${{ inputs.STRAIN_PATH }}
     env:
-      TUTOR_ROOT: strains/${{ inputs.STRAIN_PATH }}
-      TUTOR_PLUGINS_ROOT: strains/${{ inputs.STRAIN_PATH }}/plugins
+      TUTOR_ROOT: ${{ github.workspace }}/strains/${{ inputs.STRAIN_PATH }}
+      TUTOR_PLUGINS_ROOT: ${{ github.workspace }}/strains/${{ inputs.STRAIN_PATH }}/plugins
 
     steps:
       - name: Checkout Picasso repository for utility scripts


### PR DESCRIPTION
## Description
This PR drops the usage of TVM to leverage the fact that we're running on isolated environments (GH hosted runners) and don't need the overhead of installing libraries for this purpose. In the foreseeable future, we might consider returning to using TVM if we adopt building images with a sharing resources approach, as with Jenkins. Still, with the current state of the implementation, the easiest maintainability route is to drop it altogether.

## How to test

1. Go to edxn-strains repository where the caller workflow for Picasso is hosted: https://github.com/eduNEXT/ednx-strains/actions
2. To manually trigger the `ednx-strains/.github/build.yml` workflow execution, go to Actions >  Build Open edX strain, fill in the necessary configuration, please use the workflow version from `MJG/remove-tvm`. For the strain to build, I suggest using the `MJG/remove-tvm` strain branch to avoid overriding the current image on dockerhub. 
4. Press run workflow.
