### PR TITLE
feat: add script to detect errors during the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: edunext/picasso
-          ref: dcoa/false-positive
+          ref: main
           path: picasso
 
       - name: Checkout strains repository for build configurations

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: edunext/picasso
-          ref: main
+          ref: dcoa/false-positive
           path: picasso
 
       - name: Checkout strains repository for build configurations
@@ -146,10 +146,18 @@ jobs:
         working-directory: strains/${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}
         env:
           SERVICE: ${{ inputs.SERVICE }}
+          LOGS_FILE_PATH: /tmp/build_logs.out
         run: |
           . .tvm/bin/activate
           tutor config save
-          tutor images build $SERVICE --no-cache
+          (tutor images build $SERVICE --no-cache 2>&1) | tee $LOGS_FILE_PATH
+      
+      - name: Identify silent errors
+        env:
+          SCRIPT_PATH: picasso/.github/workflows/scripts/identify_silent_errors.py
+          LOGS_FILE_PATH: /tmp/build_logs.out
+        run: |
+          python $SCRIPT_PATH $LOGS_FILE_PATH
 
       - name: Push service image to registry
         working-directory: strains/${{ inputs.STRAIN_PATH }}/${{ env.TUTOR_APP_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
           tutor config save
           (tutor images build $SERVICE --no-cache 2>&1) | tee $LOGS_FILE_PATH
       
-      - name: Identify silent errors
+      - name: Scan build logs for potential errors in the image
         env:
           SCRIPT_PATH: picasso/.github/workflows/scripts/identify_silent_errors.py
           LOGS_FILE_PATH: /tmp/build_logs.out

--- a/.github/workflows/scripts/identify_silent_errors.py
+++ b/.github/workflows/scripts/identify_silent_errors.py
@@ -1,0 +1,83 @@
+"""Script to search for errors in the build process and stop the workflow. 
+Also highlight some warings.
+
+To use this script, you need to:
+
+1. Pass the required and optional keys as command-line arguments.
+2. The script will print the error or warning line.
+3. Prevent the execution of the next step if a error is detected.
+
+You can run the script using the following command:
+
+python ./scripts/identify_silent_errors.py {{ file_path }}
+
+See the `parse_args` function for more details on the command-line arguments. Find a usage example in the `.github/workflows/build.yml` file.
+"""
+
+import re
+import sys
+import argparse
+
+
+def parse_error(build_logs: str):
+    """
+    Search for errors that does not stop the build process but
+    result in an unusable image.
+
+    Arg:
+        build_logs: Build process logs to scan
+    """
+    error_list = [
+        "^Error",
+        "ValueError",
+        "Theme not found",
+        "ERROR: Repository not found",
+    ]
+
+    warning_list = [
+        "fatal: not a git repository (or any of the parent directories): .git",
+        "Error: No such command 'init'",
+    ]
+
+    for line_number, line in enumerate(build_logs, 1):
+        if any(keyword.lower() in line.lower() for keyword in warning_list):
+            print("\033[33m", f"Warning at line {line_number}: {line}")
+            continue
+
+        if any(re.search(keyword, line) for keyword in error_list):
+            print(
+                "\033[31m",
+                f"Error detected in build process at line {line_number}: {line}",
+            )
+            sys.exit(1)
+
+
+def parse_args():
+    """Parse command-line arguments"""
+
+    parser = argparse.ArgumentParser(
+        description="Process a build log file and search for errors."
+    )
+
+    parser.add_argument(
+        "file_path",
+        type=str,
+        help="Path to the log file",
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+    """
+    Open the logs file and read its content to be processed.
+    """
+    file_path = args.file_path
+
+    with open(file_path, "r", encoding="utf-8") as build_logs:
+        parse_error(build_logs)
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/.github/workflows/scripts/identify_silent_errors.py
+++ b/.github/workflows/scripts/identify_silent_errors.py
@@ -8,10 +8,6 @@ The cases that trigger errors are:
 1. Theme not found: This error is triggered when the PICASSO_THEMES 
 variable is not defined and the theme folder is not cloned.
 
-2. ERROR: Repository not found: This error occurs when tries to clone
- a private Django plugin.
-
-
 To use this script, you need to:
 
 1. Pass the required command-line arguments (file_path).
@@ -28,6 +24,7 @@ See the `parse_args` function for more details on the command-line arguments. Fi
 import re
 import sys
 import argparse
+from typing import TextIO
 
 # List of messages indicating critical errors
 ERROR_MESSAGE_PATTERNS = [
@@ -44,7 +41,7 @@ WARNING_MESSAGE_PATTERNS = [
 ]
 
 
-def parse_error(build_logs):
+def parse_error(build_logs: TextIO):
     """
     Search for errors that does not stop the build process but
     result in an unusable image.

--- a/.github/workflows/scripts/identify_silent_errors.py
+++ b/.github/workflows/scripts/identify_silent_errors.py
@@ -1,7 +1,16 @@
-"""This script scans the build log for errors and warnings.
+"""
+The script is responsible for scanning build logs to detect potential errors
+and warnings that may otherwise go unnoticed (silent errors). It stops the 
+build process when a critical error is found.
 
-Warnings will be highlighted, but errors will a not-zero exit code
-to signal failure in the build process and stops the workflow. 
+The cases that trigger errors are:
+
+1. Theme not found: This error is triggered when the PICASSO_THEMES 
+variable is not defined and the theme folder is not cloned.
+
+2. ERROR: Repository not found: This error occurs when tries to clone
+ a private Django plugin.
+
 
 To use this script, you need to:
 
@@ -20,16 +29,16 @@ import re
 import sys
 import argparse
 
-# List of keywords indicating critical errors
-error_list = [
+# List of messages indicating critical errors
+ERROR_MESSAGE_PATTERNS = [
     "^Error",
     "ValueError",
     "Theme not found",
     "ERROR: Repository not found",
 ]
 
-# List of keywords indicating warnings
-warning_list = [
+# List of messages indicating warnings
+WARNING_MESSAGE_PATTERNS = [
     "fatal: not a git repository (or any of the parent directories): .git",
     "Error: No such command 'init'",
 ]
@@ -44,11 +53,11 @@ def parse_error(build_logs):
         build_logs (file object): The build log file to scan.
     """
     for line_number, line in enumerate(build_logs, 1):
-        if any(re.search(keyword, line) for keyword in warning_list):
+        if any(re.search(message, line) for message in WARNING_MESSAGE_PATTERNS):
             print("\033[33m", f"Warning at line {line_number}: {line}")
             continue
 
-        if any(re.search(keyword, line) for keyword in error_list):
+        if any(re.search(message, line) for message in ERROR_MESSAGE_PATTERNS):
             sys.exit(
                 f"\033[31m Error detected in build process at line {line_number}: {line}"
             )


### PR DESCRIPTION
**Description**

This PR has the goal to create a Python script that identify certain errors during the build process that do not trigger the stop of the job but will result in a unusable image (with errors).

The code validates a list of keywords (identified during the use of the previous Picasso workflow experience) in the build logs, if an error is defected stop the workflow to avoid push the image.

**How to test**
1. Run a new build action in [ednx-strains](https://github.com/eduNEXT/ednx-strains/actions/workflows/build.yml).
2. For the workflow configuration set `dcoa/build-fperror` in the **_"Use workflow from"_** field. 
3. You can test a error case using [readwood/base](https://github.com/eduNEXT/ednx-strains/blob/dcoa/build-fperror/redwood/base/config.yml) from the branch `dcoa/build-fperror`.
4. The workflow should launch a error in the step _**Identify Silent Errors**_ and display the line with the error, for example: https://github.com/eduNEXT/ednx-strains/actions/runs/11155542114/job/31006631218#step:16:12

**Trigger the error**

1. _**Theme not found:**_ This error is triggered when the `PICASSO_THEMES` variable is not defined and the theme folder is not cloned. [Extra context](https://edunext.atlassian.net/browse/AP-1246)

3. **_ERROR: Repository not found:_** This error occurs when tries to clone a private Django plugin.  [Extra context](https://edunext.atlassian.net/browse/AP-714)