### PR TITLE
fix: run log analysis script from github workspace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,8 +143,9 @@ jobs:
         run: |
           tutor config save
           (tutor images build $SERVICE --no-cache 2>&1) | tee $LOGS_FILE_PATH
-      
+
       - name: Scan build logs for potential errors in the image
+        working-directory: ${{ github.workspace }}
         env:
           SCRIPT_PATH: picasso/.github/workflows/scripts/identify_silent_errors.py
           LOGS_FILE_PATH: /tmp/build_logs.out


### PR DESCRIPTION
## Description

This PR fixes `No such file or directory` error by running the log analysis script from the GH workspace directory where the Picasso repository is checked out [at the beginning of the workflow](https://github.com/eduNEXT/picasso/blob/main/.github/workflows/build.yml#L59-L64).

## How to test

1. Run a new build action in [ednx-strains](https://github.com/eduNEXT/ednx-strains/actions/workflows/build.yml).
2. For the workflow configuration set `MJG/run-scripts-from-gh-workspace` in the **_"Use workflow from"_** field. 
3. You can test an error case using [readwood/base](https://github.com/eduNEXT/ednx-strains/blob/dcoa/build-fperror/redwood/base/config.yml) from the branch `MJG/run-scripts-from-gh-workspace`
4. The workflow should raise an error in the step _**Identify Silent Errors**_ and display the line with the error or success depending on the test case: https://github.com/eduNEXT/ednx-strains/actions/runs/11389463096/job/31688801895
