### PR TITLE
perf!: add timeout to avoid excess resource consumption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Description

There's an issue where the building process gets stuck when building an image in quince with themes configured https://github.com/eduNEXT/ednx-strains/actions/runs/11402841451 -- which I'm still researching, so this limitation will stop the job if it hasn't ended in a reasonable time. This change is not intended to fix the issue but to avoid excess resource consumption in similar cases.