### PR TITLE
fix: use working directory when running scan logs script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,7 @@ jobs:
           (tutor images build $SERVICE --no-cache 2>&1) | tee $LOGS_FILE_PATH
 
       - name: Scan build logs for potential errors in the image
+        working-directory: ${{ github.workspace }}
         env:
           SCRIPT_PATH: picasso/.github/workflows/scripts/identify_silent_errors.py
           LOGS_FILE_PATH: /tmp/build_logs.out


### PR DESCRIPTION
### Description

This PR #30 removed this line by accident and I completely missed it before merging.