### PR TITLE
feat: add dynamic image tags based on service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           REQUIRED_KEYS: TUTOR_VERSION
-          OPTIONAL_KEYS: DOCKER_REGISTRY
+          OPTIONAL_KEYS: DOCKER_REGISTRY ENABLE_DYNAMIC_IMAGE_TAG REPO_BASE
           CONFIG_FILE: strains/${{ inputs.STRAIN_PATH }}/config.yml
           SCRIPT_PATH: picasso/.github/workflows/scripts/get_tutor_config.py
         run: |
@@ -124,6 +124,29 @@ jobs:
       - name: Execute extra commands
         run: |
           tutor picasso run-extra-commands
+
+      - name: Get current time
+        if: ${{ env.ENABLE_DYNAMIC_IMAGE_TAG == 'true' }}
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DD-HH-mm
+
+      - name: Set docker image tag based on service
+        if: ${{ env.ENABLE_DYNAMIC_IMAGE_TAG == 'true'}}
+        env:
+          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY || 'docker.io' }}
+          REPO_BASE: ${{ env.REPO_BASE || format('tutor-openedx/{0}-tutor', inputs.SERVICE) }}
+          SERVICE: ${{ inputs.SERVICE }}
+          TIMESTAMP: ${{ steps.current-time.outputs.formattedTime }}
+        run: |
+          if [ "$SERVICE" = "openedx" ]; then
+            DOCKER_IMAGE="DOCKER_IMAGE_${SERVICE^^}"
+          else
+            DOCKER_IMAGE="${SERVICE^^}_DOCKER_IMAGE"
+          fi
+
+          tutor config save --set "${DOCKER_IMAGE}=${DOCKER_REGISTRY}/${REPO_BASE}:${TUTOR_VERSION#v}-${TIMESTAMP}"
 
       - name: Limit build parallelism to decrease resource usage
         if: ${{ inputs.ENABLE_LIMIT_BUILDKIT_PARALLELISM }}


### PR DESCRIPTION
### Description

This PR aims to add a feature to set Open edX images tags dinamically based on service. It also helps to standarize the way tags are built for different organizations.
The variable needed to enable this feature should be defined at the strain config file as: 

| **Element**        | **Description**                                             | **Required**       | **Default Value**                               |
|--------------------|-------------------------------------------------------------|--------------------|------------------------------------------------|
| `DOCKER_REGISTRY`  | The Docker registry where images are stored.                | Optional           | `docker.io`                                    |
| `REPO_BASE`        | The base of the Docker repository for the service.          | Optional           | `tutor-openedx/{service}-tutor`                |
| `TUTOR_VERSION`    | The version of Tutor used.                                  | Required           |  -                           |
| `TIMESTAMP`        | a timestamp with the format YYYY-MM-DD-HH-mm          |  -          | Automatically generated if the feature is enabled. |

### How to test
- Add this key-value to your strain config.yml file:
```yaml
ENABLE_DYNAMIC_IMAGE_TAG: true
```
- Build an image for any service

### Optional
The default value for REPO_BASE is also built dinamically if not provided.
 If the default does not work for your case just define a custom repository path: 
```yaml
REPO_BASE: my-registry/repo-base
```

### Other considerations
There is also a possiblity to just ask for dispatch to pass a complete BASE_TAG that includes all the path but the timestamp. e.g:
```yaml
tutor config save --set "${DOCKER_IMAGE}=${BASE_TAG}-${TIMESTAMP}"
# or keeping TUTOR_VERSION 
tutor config save --set "${DOCKER_IMAGE}=${REGISTRY_BASE}:${TUTOR_VERSION#v}-${TIMESTAMP}"
```
The one that I am proposing consider reusing variables that the workflow already uses.