### PR TITLE
fix: conditionally pass ssh key for strain checkout when needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,12 +78,20 @@ jobs:
           ref: ${{ inputs.PICASSO_VERSION }}
           path: picasso
 
-      - name: Checkout strains repository for build configurations
+      - name: Checkout external strain repository
+        if: ${{ inputs.STRAIN_REPOSITORY != github.repository }}
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.STRAIN_REPOSITORY }}
           ref: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          path: strains
+
+      - name: Checkout current repository as strain source
+        if: ${{ inputs.STRAIN_REPOSITORY == github.repository }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
           path: strains
 
       - name: Setup Python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,13 +78,13 @@ jobs:
           ref: ${{ inputs.PICASSO_VERSION }}
           path: picasso
 
-      - name: Checkout strain repository
+      - name: Checkout strains repository for build configurations
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.STRAIN_REPOSITORY }}
           ref: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-          path: strains
           ssh-key: ${{ inputs.STRAIN_REPOSITORY != github.repository && secrets.SSH_PRIVATE_KEY || '' }}
+          path: strains
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,21 +78,13 @@ jobs:
           ref: ${{ inputs.PICASSO_VERSION }}
           path: picasso
 
-      - name: Checkout external strain repository
-        if: ${{ inputs.STRAIN_REPOSITORY != github.repository }}
+      - name: Checkout strain repository
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.STRAIN_REPOSITORY }}
           ref: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           path: strains
-
-      - name: Checkout current repository as strain source
-        if: ${{ inputs.STRAIN_REPOSITORY == github.repository }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-          path: strains
+          ssh-key: ${{ inputs.STRAIN_REPOSITORY != github.repository && secrets.SSH_PRIVATE_KEY || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
> #### What does this PR do?
This PR updates the `Picasso V2` workflow to conditionally pass an SSH key to the `actions/checkout@v4` step only when necessary — specifically when the strain repository differs from the current repository.

> #### Why is this change necessary?
We're supporting workflows triggered from external client repositories (outside the `eduNEXT` organization), which often contain their own strain definitions. However, those strains may include private plugins or dependencies from private `eduNEXT` repositories, which require SSH authentication.

We want to use an SSH key **only when accessing external repositories**, not when checking out the current repo — to avoid unnecessary complexity, reduce security risk, and prevent potential fetch errors.

> #### What approach was taken?
We updated the  `actions/checkout@v4` step with a conditional `ssh-key:` value:
- When the strain repo is external → `ssh-key` is passed from secrets
- When it's the current repo → an empty string is passed (`''`), and checkout uses the default GitHub token