### PR TITLE
Update commit feature to allow configuring the config.yml path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
         if: ${{ inputs.USE_DYNAMIC_IMAGE_TAG && inputs.UPDATE_IMAGE_TAG_IN_REPO }}
         working-directory: ${{ github.workspace }}/strains
         env:
-          CONFIG_FILE: build/config.yml
+          CONFIG_FILE: ${{ inputs.STRAIN_PATH }}/config.yml
           SERVICE: ${{ inputs.SERVICE }}
           SCRIPT_PATH: ../picasso/.github/workflows/scripts/dynamic_image_tag.py
         run: |


### PR DESCRIPTION
This setting allows configuring a config.yml path, in case it's not build/config.yml, as is the case for edunext hosting clients using the monorepo.