### PR TITLE
feat: allow to do git commits with a custom user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,16 @@ on:
         required: false
         type: string
         default: "%Y%m%d-%H%M"
+      GIT_COMMIT_USER_NAME:
+        description: "The name of the user used to do commit changes."
+        required: false
+        type: string
+        default: "GitHub Actions"
+      GIT_COMMIT_USER_EMAIL:
+        description: "The email address of the user used to do commit changes."
+        required: false
+        type: string
+        default: "actions@github.com"
     secrets:
       DOCKERHUB_USERNAME:
         description: 'DockerHub username for login'
@@ -285,8 +295,8 @@ jobs:
           SERVICE: ${{ inputs.SERVICE }}
           SCRIPT_PATH: ../picasso/.github/workflows/scripts/dynamic_image_tag.py
         run: |
-          git config user.name "GitHub Actions" 
-          git config user.email "actions@github.com"
+          git config user.name "${{ inputs.GIT_COMMIT_USER_NAME }}"
+          git config user.email "${{ inputs.GIT_COMMIT_USER_EMAIL }}"
           git stash
           git pull origin ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
           python $SCRIPT_PATH \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,73 +4,73 @@ on:
   workflow_call:
     inputs:
       STRAIN_REPOSITORY:
-        description: 'The repository for strains to checkout. It should follow the format: ORGANIZATION/REPO'
+        description: "The repository for strains to checkout. It should follow the format: ORGANIZATION/REPO"
         required: true
         type: string
       STRAIN_REPOSITORY_BRANCH:
-        description: 'The branch of the repository to checkout'
+        description: "The branch of the repository to checkout"
         required: true
         type: string
       STRAIN_PATH:
-        description: 'The path within the repository for strains'
+        description: "The path within the repository for strains"
         required: true
         type: string
       SERVICE:
-        description: 'The service name to build'
+        description: "The service name to build"
         required: true
         type: string
       BUILDKIT_MAX_PARALLELISM:
-        description: 'Enable buildkit parallelism limit to decrease resource usage. Default is true'
+        description: "Enable buildkit parallelism limit to decrease resource usage. Default is true"
         required: false
         type: number
         default: 0
       RUNNER_WORKFLOW_LABEL:
-        description: 'The label of the runner workflow to run'
+        description: "The label of the runner workflow to run"
         required: false
         type: string
-        default: 'ubuntu-24.04'
+        default: "ubuntu-24.04"
       PYTHON_VERSION:
-        description: 'Python version to use for the workflow'
+        description: "Python version to use for the workflow"
         required: false
         type: string
-        default: '3.12'
+        default: "3.12"
       PICASSO_VERSION:
-        description: 'Picasso version to use for the workflow scripts and utility functions. This should be a valid branch, tag or commit and it should match the version of the workflow used.'
+        description: "Picasso version to use for the workflow scripts and utility functions. This should be a valid branch, tag or commit and it should match the version of the workflow used."
         required: false
         type: string
-        default: 'v1'
+        default: "v1"
       USE_DYNAMIC_IMAGE_TAG:
-        description: 'If set to true, the image tag defined in config.yml will be ignored, and a dynamically generated tag will be used instead.'
+        description: "If set to true, the image tag defined in config.yml will be ignored, and a dynamically generated tag will be used instead."
         required: false
         type: boolean
         default: false
       UPDATE_IMAGE_TAG_IN_REPO:
-        description: 'If this field is set to true, a commit will be created with the updated image tag name in the config.yml file'
+        description: "If this field is set to true, a commit will be created with the updated image tag name in the config.yml file"
         required: false
         type: boolean
         default: false
       CLEAN_UP_DISK_SPACE:
-        description: 'If this field is set to true, some pre-installed resources on the runner will be removed.'
+        description: "If this field is set to true, some pre-installed resources on the runner will be removed."
         required: false
         type: boolean
         default: true
       ADD_RANDOM_SUFFIX_TO_IMAGE_TAG:
-        description: 'Appends a random four-character alphanumeric suffix to the image tag by default. If RANDOM_SUFFIX_LENGTH is defined, the length of the suffix will be determined by that setting. This option is only used if USE_DYNAMIC_IMAGE_TAG is enabled.'
+        description: "Appends a random four-character alphanumeric suffix to the image tag by default. If RANDOM_SUFFIX_LENGTH is defined, the length of the suffix will be determined by that setting. This option is only used if USE_DYNAMIC_IMAGE_TAG is enabled."
         required: false
         type: boolean
         default: false
       RANDOM_SUFFIX_LENGTH:
-        description: 'Specifies the number of random characters to append as a random suffix'
+        description: "Specifies the number of random characters to append as a random suffix"
         required: false
         type: string
         default: "4"
       IMAGE_TAG_PREFIX:
-        description: 'Prefix added to the dynamically generated image tag. Only used if USE_DYNAMIC_IMAGE_TAG is enabled.'
+        description: "Prefix added to the dynamically generated image tag. Only used if USE_DYNAMIC_IMAGE_TAG is enabled."
         required: false
         type: string
         default: ""
       TIMESTAMP_FORMAT:
-        description: 'Timestamp format used in the generated image tag. Follows Python’s strftime syntax. Only used if USE_DYNAMIC_IMAGE_TAG is enabled.'
+        description: "Timestamp format used in the generated image tag. Follows Python’s strftime syntax. Only used if USE_DYNAMIC_IMAGE_TAG is enabled."
         required: false
         type: string
         default: "%Y%m%d-%H%M"
@@ -86,25 +86,25 @@ on:
         default: "actions@github.com"
     secrets:
       DOCKERHUB_USERNAME:
-        description: 'DockerHub username for login'
+        description: "DockerHub username for login"
         required: false
       DOCKERHUB_PASSWORD:
-        description: 'DockerHub password for login'
+        description: "DockerHub password for login"
         required: false
       SSH_PRIVATE_KEYS:
-        description: 'One or more SSH private keys (multiline). Supports multiple deploy keys.'
+        description: "One or more SSH private keys (multiline). Supports multiple deploy keys."
         required: false
       SSH_PRIVATE_KEY:
-        description: 'DEPRECATED: single SSH key'
+        description: "DEPRECATED: single SSH key"
         required: false
       AWS_ACCESS_KEY_ID:
-        description: 'AWS access key ID'
+        description: "AWS access key ID"
         required: false
       AWS_SECRET_ACCESS_KEY:
-        description: 'AWS secret access key'
+        description: "AWS secret access key"
         required: false
       AWS_REGION:
-        description: 'AWS region'
+        description: "AWS region"
         required: false
 
 jobs:
@@ -294,9 +294,11 @@ jobs:
           CONFIG_FILE: ${{ inputs.STRAIN_PATH }}/config.yml
           SERVICE: ${{ inputs.SERVICE }}
           SCRIPT_PATH: ../picasso/.github/workflows/scripts/dynamic_image_tag.py
+          GIT_COMMIT_USER_NAME: ${{ inputs.GIT_COMMIT_USER_NAME }}
+          GIT_COMMIT_USER_EMAIL: ${{ inputs.GIT_COMMIT_USER_EMAIL }}
         run: |
-          git config user.name "${{ inputs.GIT_COMMIT_USER_NAME }}"
-          git config user.email "${{ inputs.GIT_COMMIT_USER_EMAIL }}"
+          git config user.name "$GIT_COMMIT_USER_NAME"
+          git config user.email "$GIT_COMMIT_USER_EMAIL"
           git stash
           git pull origin ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
           python $SCRIPT_PATH \

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,14 @@ Before using the workflow, ensure that you have set up the following configurati
      - Timestamp format used in the generated image tag. Follows Python’s ``strftime`` syntax. Only used if ``USE_DYNAMIC_IMAGE_TAG`` is enabled. Default is ``%Y%m%d-%H%M``
      - string
      - Input
+   * - GIT_COMMIT_USER_NAME (Optional):
+     - The name of the user used to do commit changes. Default is `GitHub Actions`
+     - string
+     - Input
+   * - GIT_COMMIT_USER_EMAIL (Optional):
+     - The email address of the user used to do commit changes. Default is `actions@github.com`
+     - string
+     - Input
 
 Private Repository Access (Multiple SSH Keys)
 *********************************************
@@ -267,4 +275,3 @@ Please do not report security vulnerabilities in public forums. Instead, email t
     :alt: License
 
 .. |status-badge| image:: http://badges.github.io/stability-badges/dist/Status-Maintained-brightgreen.svg
-  


### PR DESCRIPTION
## Description

This PR allows Picasso's users to set a custom user and email for the git commit step. The default values of the new inputs are the same as it was assigned earlier, therefore not setting the values result in the same GitHub user and email address as it was before this PR.